### PR TITLE
HMRC have recovered their redirect for ER data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## Unreleased
+
+### Fix
+
+* HMRC have recovered their redirect for ER data. [Ben Dalling]
+
+
 ## 1.4.0 (2025-07-25)
 
 ### Features

--- a/workflows/gbp_exchange_rates.py
+++ b/workflows/gbp_exchange_rates.py
@@ -94,9 +94,8 @@ class ExchangeRate:
 
         for iso_month in months:
             month = datetime.datetime.strptime(iso_month, '%Y-%m')
-            url = f'file://{os.environ["HOME"]}/Downloads/exrates-monthly-'
-            shortended_year = month.year - 2000
-            url += f'{month.month:02}{shortended_year}.csv'
+            url = f'https://www.trade-tariff.service.gov.uk/uk/api/exchange_rates/files/monthly_csv_'
+            url += f'{month.year}-{month.month}.csv'
             logger.info(f'Reading from "{url}".')
 
             with smart_open.open(url, 'rt') as stream:


### PR DESCRIPTION
We had problems yesterday with the URL, this now seems to have been fixed and now reverting to extracting the data from a remote URL rather than a manually downloaded data file.